### PR TITLE
add detail to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,13 @@ Download.from(url, options)
 * Uses httpoison
 
 ## Installation
-
+Into mix.exs:
 ```elixir
 def deps do
   [{:download, "~> x.x.x"}]
 end
 ```
-
-Into `mix.exs`
-
+Only in elixir 1.2 an below:
 ``` elixir
 def application do
   [applications: [:download]]

--- a/README.md
+++ b/README.md
@@ -19,15 +19,13 @@ Download.from(url, options)
 * Uses httpoison
 
 ## Installation
-
+Into mix.exs:
 ```elixir
 def deps do
   [{:download, "~> x.x.x"}]
 end
 ```
-
-Into `mix.exs`
-
+Only in elixir 1.3 an below:
 ``` elixir
 def application do
   [applications: [:download]]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ def deps do
   [{:download, "~> x.x.x"}]
 end
 ```
-Only in elixir 1.2 an below:
+Only in elixir 1.3 an below:
 ``` elixir
 def application do
   [applications: [:download]]


### PR DESCRIPTION
In elixir 1.3 and above you do not need to add the dependencies as applications in the mix.exs.