### PR TITLE
Use a local server in tests

### DIFF
--- a/lib/download.ex
+++ b/lib/download.ex
@@ -116,8 +116,6 @@ defmodule Download do
 
   defp handle_async_response_chunk(%AsyncEnd{}, opts), do: finish_download({ :ok }, opts)
 
-  # Uncomment one line below if you are prefer to test not "Content-Length" header response, but a real file size
-  # defp do_handle_content_length(_, opts), do: do_download(opts)
   defp do_handle_content_length({ "Content-Length", content_length }, opts) do
     if String.to_integer(content_length) > opts.max_file_size do
       finish_download({ :error, :file_size_is_too_big }, opts)

--- a/mix.exs
+++ b/mix.exs
@@ -35,8 +35,9 @@ defmodule Download.Mixfile do
   defp deps do
     [
       {:httpoison, ">= 0.9.0"},
-      {:exvcr, "~> 0.8", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev},
+      {:cowboy, "~> 1.1", only: :test},
+      {:plug, "~> 1.3", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
 %{"certifi": {:hex, :certifi, "1.2.1", "c3904f192bd5284e5b13f20db3ceac9626e14eeacfbb492e19583cf0e37b22be", [:rebar3], [], "hexpm"},
+  "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "exactor": {:hex, :exactor, "2.2.3", "a6972f43bb6160afeb73e1d8ab45ba604cd0ac8b5244c557093f6e92ce582786", [:mix], [], "hexpm"},
@@ -9,6 +11,9 @@
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], [], "hexpm"},
   "meck": {:hex, :meck, "0.8.7", "ebad16ca23f685b07aed3bc011efff65fbaf28881a8adf925428ef5472d390ee", [:rebar3], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
+  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
+  "plug": {:hex, :plug, "1.3.5", "7503bfcd7091df2a9761ef8cecea666d1f2cc454cbbaf0afa0b6e259203b7031", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.2.0", "dbbccf6781821b1c0701845eaf966c9b6d83d7c3bfc65ca2b78b88b8678bfa35", [:rebar3], [], "hexpm"}}

--- a/test/download_test.exs
+++ b/test/download_test.exs
@@ -1,19 +1,24 @@
 defmodule DownloadTest do
   use ExUnit.Case
 
-  @remote_file_url "http://speedtest.ftp.otenet.gr/files/test100k.db"
-  @remote_file_size 1024 * 100
-
   @project_path System.cwd()
+
+  def test_url(opts) do
+    opts = Keyword.put_new(opts, :status, 200)
+    query = URI.encode_query(opts)
+
+    "localhost:8089/file?" <> query
+  end
 
   describe "from" do
     test "successfully downloads file" do
-      resulting_download_path = @project_path <> "/" <> "test100k.db"
+      url = test_url(size: 100)
+      resulting_download_path = @project_path <> "/" <> (url |> String.split("/") |> List.last())
 
       File.rm(resulting_download_path)
 
-      assert Download.from(@remote_file_url) == { :ok, resulting_download_path }
-      assert file_downloaded_correctly(resulting_download_path)
+      assert Download.from(url) == { :ok, resulting_download_path }
+      assert file_downloaded_correctly(resulting_download_path, 100)
 
       File.rm!(resulting_download_path)
     end
@@ -21,28 +26,41 @@ defmodule DownloadTest do
     test "files are stored to the specified path" do
       path_to_store = random_tmp_path()
 
-      assert Download.from(@remote_file_url, [path: path_to_store]) == { :ok, path_to_store }
-      assert file_downloaded_correctly(path_to_store)
+      assert Download.from(test_url(size: 100), [path: path_to_store]) == { :ok, path_to_store }
+      assert file_downloaded_correctly(path_to_store, 100)
+
+      File.rm!(path_to_store)
     end
 
     test "passes for files smaller than max_file_size" do
       path_to_store = random_tmp_path()
 
-      assert Download.from(@remote_file_url, [path: path_to_store, max_file_size: 101 * 1024]) == { :ok, path_to_store }
-      assert file_downloaded_correctly(path_to_store)
+      assert Download.from(test_url(size: 200), [path: path_to_store, max_file_size: 201]) == { :ok, path_to_store }
+      assert file_downloaded_correctly(path_to_store, 200)
+
+      File.rm!(path_to_store)
     end
 
     test "rejects for files bigger than max_file_size" do
       path_to_store = random_tmp_path()
 
-      assert Download.from(@remote_file_url, [path: path_to_store, max_file_size: 99 * 1024]) == { :error, :file_size_is_too_big }
+      assert Download.from(test_url(size: 200), [path: path_to_store, max_file_size: 199]) == { :error, :file_size_is_too_big }
       refute File.exists?(path_to_store)
     end
 
-    test "returns error for redirecting url" do
+    test "does not exceed the size specified by Content-Length" do
       path_to_store = random_tmp_path()
 
-      assert Download.from("https://github.com/tzusman/GCM-v3/eee", [path: path_to_store]) == { :error, :unexpected_status_code, 404 }
+      assert Download.from(test_url(size: 200, content_length: 100), [path: path_to_store, max_file_size: 101]) == { :ok, path_to_store }
+      assert file_downloaded_correctly(path_to_store, 100)
+
+      File.rm!(path_to_store)
+    end
+
+    test "returns error for non-200 status codes" do
+      path_to_store = random_tmp_path()
+
+      assert Download.from(test_url(size: 10, status: 404), [path: path_to_store]) == { :error, :unexpected_status_code, 404 }
       refute File.exists?(path_to_store)
     end
 
@@ -56,12 +74,12 @@ defmodule DownloadTest do
     test "returns error if file exists already" do
       path_to_store = System.cwd() <> "/" <> "mix.exs"
 
-      assert Download.from(@remote_file_url, [path: path_to_store]) == { :error, :eexist }
+      assert Download.from(test_url(size: 100), [path: path_to_store]) == { :error, :eexist }
     end
   end
 
-  defp file_downloaded_correctly(path) do
-    File.exists?(path) && File.stat!(path).size == @remote_file_size
+  defp file_downloaded_correctly(path, size) do
+    File.exists?(path) && File.stat!(path).size == size
   end
 
   # Add something for windows os here?

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,26 @@
 ExUnit.start()
+
+defmodule TestServer do
+  import Plug.Conn
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    conn = fetch_query_params(conn)
+
+    resp_size = parse_numeric(conn.query_params["size"])
+    resp_status = parse_numeric(conn.query_params["status"])
+    body = :binary.copy(<<0>>, resp_size)
+
+    content_length = conn.query_params["content_length"]
+    conn = if content_length,
+      do: put_resp_header(conn, "content-length", content_length),
+      else: conn
+
+    send_resp(conn, resp_status, body)
+  end
+
+  defp parse_numeric(binary), do: binary |> Integer.parse() |> elem(0)
+end
+
+{:ok, _} = Plug.Adapters.Cowboy.http(TestServer, [], port: 8089)


### PR DESCRIPTION
Hello! I'd like to thank you for this project, it seems to suit my use cases and avoids some mistakes I probably would've made had I had to do it myself (namely, downloading the whole file in memory instead of streaming it).

If you don't mind, I suggest you to use a local server for the test suite. This allows you to test corner cases by fine tuning the response size, status, and headers, not to mention it doesn't require an Internet connection in development.

I was also slightly confused by `"Uncomment the line below to check the real size"` in code. I think it can be safely removed, because apparently HTTPoison won't exceed the size reported by Content-Length anyway (see the test case I've added).