### PR TITLE
Add option to follow redirect

### DIFF
--- a/test/download_test.exs
+++ b/test/download_test.exs
@@ -58,6 +58,11 @@ defmodule DownloadTest do
 
       assert Download.from(@remote_file_url, [path: path_to_store]) == { :error, :eexist }
     end
+
+    test "follows single redirect" do
+      path = random_tmp_path()
+      assert Download.from("http://fast.com", follow_redirect: true, path: path) == { :ok, path }
+    end
   end
 
   defp file_downloaded_correctly(path) do


### PR DESCRIPTION
Uses built-in redirect following from HTTPoison and makes a new request when a redirect is received.

The test simply checks that fast.com can be downloaded (it doesn't serve over HTTP, so the URL redirects to HTTPS)